### PR TITLE
remove the comment on `sha2` version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "drand-client-rs"
-description = "A small rust library for retrieving random numbers from drand"
+description = "a small Rust library for retrieving random numbers from `drand`"
 version = "0.2.0"
 edition = "2021"
 license = "MIT"
@@ -8,8 +8,8 @@ license = "MIT"
 [dependencies]
 bls12_381 = { version = "0.8.0", features = ["experimental"] }
 hex = { version = "0.4.3", features = ["serde"] }
-reqwest = { version = "0.11.20", features = ["blocking", "json"] }
+reqwest = { version = "0.12", features = ["blocking", "json"] }
 serde = { version = "1.0.187", features = ["derive"] }
 serde_json = "1.0.105"
-sha2 = "0.9" # this can't be upgraded for compat with bls12_381 it seems :<
-thiserror = "1.0.38"
+sha2 = "0.9" 
+thiserror = "2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@ pub struct DrandClient<'a, T: Transport> {
 /// create a new instance of the client with an HTTP transport for a given `base_url`.
 /// Supported `base_url`s include: "<https://api.drand.sh>", "<https://drand.cloudflare.com>" and "<https://api.drand.secureweb3.com:6875>".
 /// A full list can be found at <https://drand.love/developer/>
-pub fn new_http_client(base_url: &str) -> Result<DrandClient<HttpTransport>, DrandClientError> {
+pub fn new_http_client(base_url: &str) -> Result<DrandClient<'_, HttpTransport>, DrandClientError> {
     let http_transport = new_http_transport();
     let chain_info = fetch_chain_info(&http_transport, base_url)?;
     Ok(DrandClient {


### PR DESCRIPTION
It picked my eye, so I took it as a chance to look inside a `randa-mu` crate. Found the comment is not relevant as `sha2` isn't part of API; so it's no different as if that was re-exported by the BLS crate

Other changes were made along the way just "by the inertia". :shrug: